### PR TITLE
fix(serializer): sixel ratio 1:1 no bg erase

### DIFF
--- a/src/sixel_serializer.rs
+++ b/src/sixel_serializer.rs
@@ -31,7 +31,7 @@ impl <'a>SixelSerializer <'a>{
         serialized_image
     }
     fn serialize_empty_dcs(&self, mut append_to: String) -> String {
-        append_to.push_str("\u{1b}Pq");
+        append_to.push_str("\u{1b}P9;1q");
         append_to
     }
     fn serialize_color_registers(&self, mut append_to: String) -> String {


### PR DESCRIPTION
Sets the default sixel ratio to 1:1 since most terminals either do not support ratios or default to another ratio. Disables background erase, this fixes the black backgrounds on transparent sixels. https://github.com/zellij-org/zellij/issues/2048#issuecomment-2613617163

Before:
![image](https://github.com/user-attachments/assets/92e2eb41-d204-4685-94b4-76991c5d8753)

After:
![image](https://github.com/user-attachments/assets/e6814041-6b2a-4a6b-be07-2757e75055d3)
